### PR TITLE
Support strict_variables by removing dynamic lookups

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -48,7 +48,7 @@
 class snmp::client (
   $snmp_config        = $snmp::params::snmp_config,
   $ensure             = $snmp::params::ensure,
-  $autoupgrade        = $snmp::params::safe_autoupgrade,
+  $autoupgrade        = $snmp::params::autoupgrade,
   $package_name       = $snmp::params::client_package_name
 ) inherits snmp::params {
   # Validate our booleans

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -242,7 +242,7 @@ class snmp (
   $install_client          = $snmp::params::install_client,
   $snmp_config             = $snmp::params::snmp_config,
   $ensure                  = $snmp::params::ensure,
-  $autoupgrade             = $snmp::params::safe_autoupgrade,
+  $autoupgrade             = $snmp::params::autoupgrade,
   $package_name            = $snmp::params::package_name,
   $snmpd_options           = $snmp::params::snmpd_options,
   $service_ensure          = $snmp::params::service_ensure,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -14,221 +14,60 @@
 # Copyright (C) 2012 Mike Arnold, unless otherwise noted.
 #
 class snmp::params {
-  # If we have a top scope variable defined, use it, otherwise fall back to a
-  # hardcoded value.
-  $agentaddress = $::snmp_agentaddress ? {
-    undef   => [ 'udp:127.0.0.1:161' ],
-    default => $::snmp_agentaddress,
-  }
+  $agentaddress = [ 'udp:127.0.0.1:161' ]
+  $snmptrapdaddr = [ 'udp:127.0.0.1:162' ]
+  $ro_community = 'public'
+  $rw_community = undef
+  $ro_network = '127.0.0.1'
+  $rw_network = '127.0.0.1'
+  $contact = 'Unknown'
+  $location = 'Unknown'
 
-  $snmptrapdaddr = $::snmp_snmptrapdaddr ? {
-    undef   => [ 'udp:127.0.0.1:162' ],
-    default => $::snmp_snmptrapdaddr,
-  }
+  $com2sec = [
+    "notConfigUser  default       ${ro_community}",
+  ]
 
-  $ro_community = $::snmp_ro_community ? {
-    undef   => 'public',
-    default => $::snmp_ro_community,
-  }
+  $groups = [
+    'notConfigGroup v1            notConfigUser',
+    'notConfigGroup v2c           notConfigUser',
+  ]
 
-  $rw_community = $::snmp_rw_community ? {
-    undef   => undef,
-    default => $::snmp_rw_community,
-  }
+  $services = 72
 
-  $ro_network = $::snmp_ro_network ? {
-    undef   => '127.0.0.1',
-    default => $::snmp_ro_network,
-  }
+  $views = [
+    'systemview    included   .1.3.6.1.2.1.1',
+    'systemview    included   .1.3.6.1.2.1.25.1.1',
+  ]
 
-  $rw_network = $::snmp_rw_network ? {
-    undef   => '127.0.0.1',
-    default => $::snmp_rw_network,
-  }
+  $accesses = [
+    'notConfigGroup ""      any       noauth    exact  systemview none  none',
+  ]
 
-  $contact = $::snmp_contact ? {
-    undef   => 'Unknown',
-    default => $::snmp_contact,
-  }
-
-  $location = $::snmp_location ? {
-    undef   => 'Unknown',
-    default => $::snmp_location,
-  }
-
-  $com2sec = $::snmp_com2sec ? {
-    undef   => [
-      "notConfigUser  default       ${ro_community}",
-    ],
-    default => $::snmp_com2sec,
-  }
-
-  $groups = $::snmp_groups ? {
-    undef   => [
-      'notConfigGroup v1            notConfigUser',
-      'notConfigGroup v2c           notConfigUser',
-    ],
-    default => $::snmp_groups,
-  }
-
-  $services = $::snmp_services ? {
-    undef   => 72,
-    default => $::snmp_services,
-  }
-
-  $views = $::snmp_views ? {
-    undef   => [
-      'systemview    included   .1.3.6.1.2.1.1',
-      'systemview    included   .1.3.6.1.2.1.25.1.1',
-    ],
-    default => $::snmp_views,
-  }
-
-  $accesses = $::snmp_accesses ? {
-    undef   => [
-      'notConfigGroup ""      any       noauth    exact  systemview none  none',
-    ],
-    default => $::snmp_accesses,
-  }
-
-  $dlmod = $::snmp_dlmod ? {
-    undef   => [],
-    default => $::snmp_dlmod,
-  }
-
-  $disable_authorization = $::snmp_disable_authorization ? {
-    undef   => 'no',
-    default => $::snmp_disable_authorization,
-  }
-
-  $do_not_log_traps = $::snmp_do_not_log_traps ? {
-    undef   => 'no',
-    default => $::snmp_do_not_log_traps,
-  }
-
-  $trap_handlers = $::snmp_trap_handlers ? {
-    undef   => [],
-    default => $::snmp_trap_handlers,
-  }
-
-  $trap_forwards = $::snmp_trap_forwards ? {
-    undef   => [],
-    default => $::snmp_trap_forwards,
-  }
-
-  $snmp_config = $::snmp_snmp_config ? {
-    undef   => [],
-    default => $::snmp_snmp_config,
-  }
-
-  $snmpd_config = $::snmp_snmpd_config ? {
-    undef   => [],
-    default => $::snmp_snmpd_config,
-  }
-
-  $snmptrapd_config = $::snmp_snmptrapd_config ? {
-    undef   => [],
-    default => $::snmp_snmptrapd_config,
-  }
+  $dlmod = []
+  $disable_authorization = 'no'
+  $do_not_log_traps = 'no'
+  $trap_handlers = []
+  $trap_forwards = []
+  $snmp_config = []
+  $snmpd_config = []
+  $snmptrapd_config = []
 
 ### The following parameters should not need to be changed.
 
-  $ensure = $::snmp_ensure ? {
-    undef   => 'present',
-    default => $::snmp_ensure,
-  }
-
-  $service_ensure = $::snmp_service_ensure ? {
-    undef   => 'running',
-    default => $::snmp_service_ensure,
-  }
-
-  $trap_service_ensure = $::snmp_trap_service_ensure ? {
-    undef   => 'stopped',
-    default => $::snmp_trap_service_ensure,
-  }
+  $ensure = 'present'
+  $service_ensure = 'running'
+  $trap_service_ensure = 'stopped'
 
   # Since the top scope variable could be a string (if from an ENC), we might
   # need to convert it to a boolean.
-  $autoupgrade = $::snmp_autoupgrade ? {
-    undef   => false,
-    default => $::snmp_autoupgrade,
-  }
-  if is_string($autoupgrade) {
-    $safe_autoupgrade = str2bool($autoupgrade)
-  } else {
-    $safe_autoupgrade = $autoupgrade
-  }
-
-  $install_client = $::snmp_install_client ? {
-    undef   => false,
-    default => $::snmp_install_client,
-  }
-  if is_string($install_client) {
-    $safe_install_client = str2bool($install_client)
-  } else {
-    $safe_install_client = $install_client
-  }
-
-  $service_enable = $::snmp_service_enable ? {
-    undef   => true,
-    default => $::snmp_service_enable,
-  }
-  if is_string($service_enable) {
-    $safe_service_enable = str2bool($service_enable)
-  } else {
-    $safe_service_enable = $service_enable
-  }
-
-  $service_hasstatus = $::snmp_service_hasstatus ? {
-    undef   => true,
-    default => $::snmp_service_hasstatus,
-  }
-  if is_string($service_hasstatus) {
-    $safe_service_hasstatus = str2bool($service_hasstatus)
-  } else {
-    $safe_service_hasstatus = $service_hasstatus
-  }
-
-  $service_hasrestart = $::snmp_service_hasrestart ? {
-    undef   => true,
-    default => $::snmp_service_hasrestart,
-  }
-  if is_string($service_hasrestart) {
-    $safe_service_hasrestart = str2bool($service_hasrestart)
-  } else {
-    $safe_service_hasrestart = $service_hasrestart
-  }
-
-  $trap_service_enable = $::snmp_trap_service_enable ? {
-    undef   => false,
-    default => $::snmp_trap_service_enable,
-  }
-  if is_string($trap_service_enable) {
-    $safe_trap_service_enable = str2bool($trap_service_enable)
-  } else {
-    $safe_trap_service_enable = $trap_service_enable
-  }
-
-  $trap_service_hasstatus = $::snmp_trap_service_hasstatus ? {
-    undef   => true,
-    default => $::snmp_trap_service_hasstatus,
-  }
-  if is_string($trap_service_hasstatus) {
-    $safe_trap_service_hasstatus = str2bool($trap_service_hasstatus)
-  } else {
-    $safe_trap_service_hasstatus = $trap_service_hasstatus
-  }
-
-  $trap_service_hasrestart = $::snmp_trap_service_hasrestart ? {
-    undef   => true,
-    default => $::snmp_trap_service_hasrestart,
-  }
-  if is_string($trap_service_hasrestart) {
-    $safe_trap_service_hasrestart = str2bool($trap_service_hasrestart)
-  } else {
-    $safe_trap_service_hasrestart = $trap_service_hasrestart
-  }
+  $autoupgrade = false
+  $install_client = false
+  $service_enable = true
+  $service_hasstatus = true
+  $service_hasrestart = true
+  $trap_service_enable = false
+  $trap_service_hasstatus = true
+  $trap_service_hasrestart = true
 
   case $::osfamily {
     'RedHat': {


### PR DESCRIPTION
This pull request removes a bunch of existing functionality.  I would understand if you don't want to merge it.

My organization would like to enable strict_variables for our Puppet compilation.  The current design of this module is not compatible with strict_variables, because it uses dynamic lookups to test for parameters.  Dynamic lookups are [deprecated](https://docs.puppetlabs.com/guides/scope_and_puppet.html).

With that in mind, I propose to remove these lookups entirely in favor of class parameters.
