### PR TITLE
Fix permissions to be 640 by default on config files

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -271,7 +271,7 @@ class snmp::params {
       }
       $package_name             = 'net-snmp'
       $service_config           = '/etc/snmp/snmpd.conf'
-      $service_config_perms     = '0644'
+      $service_config_perms     = '0640'
       $service_config_dir_group = 'root'
       $service_name             = 'snmpd'
       $varnetsnmp_owner         = 'root'

--- a/spec/classes/snmp_init_spec.rb
+++ b/spec/classes/snmp_init_spec.rb
@@ -52,7 +52,7 @@ describe 'snmp', :type => 'class' do
 
         it { should contain_file('snmpd.conf').with(
           :ensure  => 'present',
-          :mode    => '0644',
+          :mode    => '0640',
           :owner   => 'root',
           :group   => 'root',
           :path    => '/etc/snmp/snmpd.conf',
@@ -101,7 +101,7 @@ describe 'snmp', :type => 'class' do
 
         it { should contain_file('snmptrapd.conf').with(
           :ensure  => 'present',
-          :mode    => '0644',
+          :mode    => '0640',
           :owner   => 'root',
           :group   => 'root',
           :path    => '/etc/snmp/snmptrapd.conf',


### PR DESCRIPTION
Arguably one could have sensistive information in the configuration files, community string etc. These can of course be read across the network in plain text, however, I believe it is just good practice to restrict ownership of config files like snmpd.conf as much as possible so that sensitive information can't be leaked that way.

-Erinn