### PR TITLE
skip zero length strings in ERB template output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: ruby
 cache:
   directories:
   - vendor/bundle
-  - spec/fixtures/modules
+#  - spec/fixtures/modules
 sudo: false
 branches:
   only:

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source ENV['GEM_SOURCE'] || "https://rubygems.org"
 
 group :development, :unit_tests do
   gem 'rake',                           :require => false
+  gem 'rspec', '~> 2.0',                :require => false
   gem 'rspec-puppet', '~> 2.0',         :require => false
   gem 'puppetlabs_spec_helper',         :require => false
   gem 'puppet-lint', '>= 1.1.0',        :require => false

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ group :development, :unit_tests do
   gem 'rake',                           :require => false
   gem 'rspec-puppet', '~> 2.0',         :require => false
   gem 'puppetlabs_spec_helper',         :require => false
-  gem 'puppet-lint',                    :require => false
+  gem 'puppet-lint', '>= 1.1.0',        :require => false
   gem 'simplecov',                      :require => false
   gem 'puppet_facts',                   :require => false
   gem 'json',                           :require => false

--- a/Gemfile
+++ b/Gemfile
@@ -1,19 +1,14 @@
 source ENV['GEM_SOURCE'] || "https://rubygems.org"
 
 group :development, :unit_tests do
-  gem 'rake',                    :require => false
-  gem 'rspec-puppet',            :require => false
-  gem 'puppetlabs_spec_helper',  :require => false
-  gem 'puppet-lint',             :require => false
-  gem 'simplecov',               :require => false
-  gem 'puppet_facts',            :require => false
-  gem 'json',                    :require => false
-  gem 'metadata-json-lint',      :require => false
-end
-
-group :system_tests do
-  gem 'beaker-rspec',  :require => false
-  gem 'serverspec',    :require => false
+  gem 'rake',                           :require => false
+  gem 'rspec-puppet', '~> 2.0',         :require => false
+  gem 'puppetlabs_spec_helper',         :require => false
+  gem 'puppet-lint',                    :require => false
+  gem 'simplecov',                      :require => false
+  gem 'puppet_facts',                   :require => false
+  gem 'json',                           :require => false
+  gem 'metadata-json-lint', '>= 0.0.4', :require => false
 end
 
 if facterversion = ENV['FACTER_GEM_VERSION']

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,6 @@
 require 'puppetlabs_spec_helper/rake_tasks'
 require 'puppet-lint/tasks/puppet-lint'
+require 'metadata-json-lint/rake_task'
 
 PuppetLint.configuration.fail_on_warnings = true
 PuppetLint.configuration.send('relative')
@@ -11,8 +12,3 @@ PuppetLint.configuration.ignore_paths = ["spec/**/*.pp", "pkg/**/*.pp", "vender/
 
 PuppetSyntax.exclude_paths = ["spec/**/*", "pkg/**/*", "vender/**/*"]
 PuppetSyntax.hieradata_paths = ["**/data/**/*.yaml", "hieradata/**/*.yaml", "hiera*.yaml"]
-
-desc "Check puppet metadata.json with metadata-json-lint."
-task :metadata do
-  sh "metadata-json-lint metadata.json"
-end

--- a/Rakefile
+++ b/Rakefile
@@ -2,13 +2,10 @@ require 'puppetlabs_spec_helper/rake_tasks'
 require 'puppet-lint/tasks/puppet-lint'
 require 'metadata-json-lint/rake_task'
 
-PuppetLint.configuration.fail_on_warnings = true
-PuppetLint.configuration.send('relative')
-PuppetLint.configuration.send('disable_80chars')
-PuppetLint.configuration.send('disable_class_inherits_from_params_class')
-PuppetLint.configuration.send('disable_documentation')
-PuppetLint.configuration.send('disable_single_quote_string_with_variables')
-PuppetLint.configuration.ignore_paths = ["spec/**/*.pp", "pkg/**/*.pp", "vender/**/*.pp"]
+Rake::Task[:lint].clear
+PuppetLint::RakeTask.new :lint do |config|
+  config.ignore_paths = ["spec/**/*.pp", "pkg/**/*.pp", "vendor/**/*.pp"]
+end
 
 PuppetSyntax.exclude_paths = ["spec/**/*", "pkg/**/*", "vender/**/*"]
 PuppetSyntax.hieradata_paths = ["**/data/**/*.yaml", "hieradata/**/*.yaml", "hiera*.yaml"]

--- a/spec/classes/snmp_client_spec.rb
+++ b/spec/classes/snmp_client_spec.rb
@@ -162,7 +162,7 @@ describe 'snmp::client', :type => 'class' do
       let(:params) {{ :snmp_config => [ 'defVersion 2c', 'defCommunity public' ] }}
       it { should contain_file('snmp.conf') }
       it 'should contain File[snmp.conf] with contents "defVersion 2c" and "defCommunity public"' do
-        verify_contents(subject, 'snmp.conf', [
+        verify_contents(catalogue, 'snmp.conf', [
           'defVersion 2c',
           'defCommunity public',
         ])

--- a/spec/classes/snmp_init_spec.rb
+++ b/spec/classes/snmp_init_spec.rb
@@ -61,7 +61,7 @@ describe 'snmp', :type => 'class' do
         )}
         # TODO add more contents for File[snmpd.conf]
         it 'should contain File[snmpd.conf] with expected contents' do
-          verify_contents(subject, 'snmpd.conf', [
+          verify_contents(catalogue, 'snmpd.conf', [
             'agentaddress udp:127.0.0.1:161,udp6:[::1]:161',
             'rocommunity public 127.0.0.1',
             'rocommunity6 public ::1',
@@ -89,7 +89,7 @@ describe 'snmp', :type => 'class' do
           :notify  => 'Service[snmpd]'
         )}
         it 'should contain File[snmpd.sysconfig] with contents "OPTIONS="-LS0-6d -Lf /dev/null -p /var/run/snmpd.pid""' do
-          verify_contents(subject, 'snmpd.sysconfig', [
+          verify_contents(catalogue, 'snmpd.sysconfig', [
             'OPTIONS="-LS0-6d -Lf /dev/null -p /var/run/snmpd.pid"',
           ])
         end
@@ -113,7 +113,7 @@ describe 'snmp', :type => 'class' do
         )}
         # TODO add more contents for File[snmptrapd.conf]
         it 'should contain File[snmptrapd.conf] with correct contents' do
-          verify_contents(subject, 'snmptrapd.conf', [
+          verify_contents(catalogue, 'snmptrapd.conf', [
             'doNotLogTraps no',
             'authCommunity log,execute,net public',
             'disableAuthorization no',
@@ -129,7 +129,7 @@ describe 'snmp', :type => 'class' do
           :notify  => 'Service[snmptrapd]'
         )}
         it 'should contain File[snmptrapd.sysconfig] with contents "OPTIONS="-Lsd -p /var/run/snmptrapd.pid""' do
-          verify_contents(subject, 'snmptrapd.sysconfig', [
+          verify_contents(catalogue, 'snmptrapd.sysconfig', [
             'OPTIONS="-Lsd -p /var/run/snmptrapd.pid"',
           ])
         end
@@ -179,7 +179,7 @@ describe 'snmp', :type => 'class' do
         )}
         # TODO add more contents for File[snmpd.conf]
         it 'should contain File[snmpd.conf] with expected contents' do
-          verify_contents(subject, 'snmpd.conf', [
+          verify_contents(catalogue, 'snmpd.conf', [
             'agentaddress udp:127.0.0.1:161,udp6:[::1]:161',
             'rocommunity public 127.0.0.1',
             'rocommunity6 public ::1',
@@ -207,7 +207,7 @@ describe 'snmp', :type => 'class' do
           :notify  => 'Service[snmpd]'
         )}
         it 'should contain File[snmpd.sysconfig] with contents "SNMPDOPTS=\'-Lsd -Lf /dev/null -u snmp -g snmp -I -smux -p /var/run/snmpd.pid\'"' do
-          verify_contents(subject, 'snmpd.sysconfig', [
+          verify_contents(catalogue, 'snmpd.sysconfig', [
             'SNMPDRUN=yes',
             'SNMPDOPTS=\'-Lsd -Lf /dev/null -u snmp -g snmp -I -smux -p /var/run/snmpd.pid\'',
           ])
@@ -232,7 +232,7 @@ describe 'snmp', :type => 'class' do
         )}
         # TODO add more contents for File[snmptrapd.conf]
         it 'should contain File[snmptrapd.conf] with correct contents' do
-          verify_contents(subject, 'snmptrapd.conf', [
+          verify_contents(catalogue, 'snmptrapd.conf', [
             'doNotLogTraps no',
             'authCommunity log,execute,net public',
             'disableAuthorization no',
@@ -240,7 +240,7 @@ describe 'snmp', :type => 'class' do
         end
         it { should_not contain_file('snmptrapd.sysconfig') }
         it 'should contain File[snmpd.sysconfig] with contents "TRAPDOPTS=\'-Lsd -p /var/run/snmptrapd.pid\'"' do
-          verify_contents(subject, 'snmpd.sysconfig', [
+          verify_contents(catalogue, 'snmpd.sysconfig', [
             'TRAPDRUN=no',
             'TRAPDOPTS=\'-Lsd -p /var/run/snmptrapd.pid\'',
           ])
@@ -284,7 +284,7 @@ describe 'snmp', :type => 'class' do
         )}
         # TODO add more contents for File[snmpd.conf]
         it 'should contain File[snmpd.conf] with expected contents' do
-          verify_contents(subject, 'snmpd.conf', [
+          verify_contents(catalogue, 'snmpd.conf', [
             'agentaddress udp:127.0.0.1:161,udp6:[::1]:161',
             'rocommunity public 127.0.0.1',
             'rocommunity6 public ::1',
@@ -312,7 +312,7 @@ describe 'snmp', :type => 'class' do
           :notify  => 'Service[snmpd]'
         )}
         it 'should contain File[snmpd.sysconfig] with contents "SNMPD_LOGLEVEL="d""' do
-          verify_contents(subject, 'snmpd.sysconfig', [
+          verify_contents(catalogue, 'snmpd.sysconfig', [
             'SNMPD_LOGLEVEL="d"',
           ])
         end
@@ -336,7 +336,7 @@ describe 'snmp', :type => 'class' do
         )}
         # TODO add more contents for File[snmptrapd.conf]
         it 'should contain File[snmptrapd.conf] with correct contents' do
-          verify_contents(subject, 'snmptrapd.conf', [
+          verify_contents(catalogue, 'snmptrapd.conf', [
             'doNotLogTraps no',
             'authCommunity log,execute,net public',
             'disableAuthorization no',
@@ -394,7 +394,7 @@ describe 'snmp', :type => 'class' do
         )}
         # TODO add more contents for File[snmpd.conf]
         it 'should contain File[snmpd.conf] with expected contents' do
-          verify_contents(subject, 'snmpd.conf', [
+          verify_contents(catalogue, 'snmpd.conf', [
             'agentaddress udp:127.0.0.1:161,udp6:[::1]:161',
             'rocommunity public 127.0.0.1',
             'rocommunity6 public ::1',
@@ -432,7 +432,7 @@ describe 'snmp', :type => 'class' do
         )}
         # TODO add more contents for File[snmptrapd.conf]
         it 'should contain File[snmptrapd.conf] with correct contents' do
-          verify_contents(subject, 'snmptrapd.conf', [
+          verify_contents(catalogue, 'snmptrapd.conf', [
             'doNotLogTraps no',
             'authCommunity log,execute,net public',
             'disableAuthorization no',
@@ -570,7 +570,7 @@ describe 'snmp', :type => 'class' do
       let(:params) {{ :snmpd_options => 'blah' }}
       it { should contain_file('snmpd.sysconfig') }
       it 'should contain File[snmpd.sysconfig] with contents "OPTIONS=\'blah\'"' do
-        verify_contents(subject, 'snmpd.sysconfig', [
+        verify_contents(catalogue, 'snmpd.sysconfig', [
           'OPTIONS="blah"',
         ])
       end
@@ -580,7 +580,7 @@ describe 'snmp', :type => 'class' do
       let(:params) {{ :snmptrapd_options => 'bleh' }}
       it { should contain_file('snmptrapd.sysconfig') }
       it 'should contain File[snmptrapd.sysconfig] with contents "OPTIONS=\'bleh\'"' do
-        verify_contents(subject, 'snmptrapd.sysconfig', [
+        verify_contents(catalogue, 'snmptrapd.sysconfig', [
           'OPTIONS="bleh"',
         ])
       end
@@ -589,7 +589,7 @@ describe 'snmp', :type => 'class' do
     describe 'com2sec => [ SomeString ]' do
       let(:params) {{ :com2sec => [ 'SomeString', ] }}
       it 'should contain File[snmpd.conf] with contents "com2sec SomeString"' do
-        verify_contents(subject, 'snmpd.conf', [
+        verify_contents(catalogue, 'snmpd.conf', [
           'com2sec SomeString',
         ])
       end
@@ -598,7 +598,7 @@ describe 'snmp', :type => 'class' do
     describe 'com2sec6 => [ SomeString ]' do
       let(:params) {{ :com2sec6 => [ 'SomeString', ] }}
       it 'should contain File[snmpd.conf] with contents "com2sec6 SomeString"' do
-        verify_contents(subject, 'snmpd.conf', [
+        verify_contents(catalogue, 'snmpd.conf', [
           'com2sec6 SomeString',
         ])
       end
@@ -607,7 +607,7 @@ describe 'snmp', :type => 'class' do
     describe 'groups => [ SomeString ]' do
       let(:params) {{ :groups => [ 'SomeString', ] }}
       it 'should contain File[snmpd.conf] with contents "groups SomeString"' do
-        verify_contents(subject, 'snmpd.conf', [
+        verify_contents(catalogue, 'snmpd.conf', [
           'group   SomeString',
         ])
       end
@@ -616,7 +616,7 @@ describe 'snmp', :type => 'class' do
     describe 'dlmod => [ SomeString ]' do
       let(:params) {{ :dlmod => [ 'SomeString', ] }}
       it 'should contain File[snmpd.conf] with contents "dlmod SomeString"' do
-        verify_contents(subject, 'snmpd.conf', [
+        verify_contents(catalogue, 'snmpd.conf', [
           'dlmod SomeString',
         ])
       end
@@ -625,7 +625,7 @@ describe 'snmp', :type => 'class' do
     describe 'openmanage_enable => true' do
         let(:params) {{ :openmanage_enable => true }}
         it 'should contain File[snmpd.conf] with contents "smuxpeer .1.3.6.1.4.1.674.10892.1"' do
-            verify_contents(subject, 'snmpd.conf', [
+            verify_contents(catalogue, 'snmpd.conf', [
                 'smuxpeer .1.3.6.1.4.1.674.10892.1',
             ])
         end
@@ -634,7 +634,7 @@ describe 'snmp', :type => 'class' do
     describe 'agentaddress => [ "1.2.3.4", "8.6.7.5:222" ]' do
       let(:params) {{ :agentaddress => ['1.2.3.4','8.6.7.5:222'] }}
       it 'should contain File[snmpd.conf] with contents "agentaddress 1.2.3.4,8.6.7.5:222"' do
-        verify_contents(subject, 'snmpd.conf', [
+        verify_contents(catalogue, 'snmpd.conf', [
           'agentaddress 1.2.3.4,8.6.7.5:222',
         ])
       end
@@ -643,7 +643,7 @@ describe 'snmp', :type => 'class' do
     describe 'do_not_log_tcpwrappers => "yes"' do
         let(:params) {{:do_not_log_tcpwrappers => 'yes'}}
         it 'should contain File[snmpd.conf] with contents "dontLogTCPWrappersConnects yes' do
-            verify_contents(subject, 'snmpd.conf', [
+            verify_contents(catalogue, 'snmpd.conf', [
                 'dontLogTCPWrappersConnects yes',
             ])
         end
@@ -652,7 +652,7 @@ describe 'snmp', :type => 'class' do
     describe 'snmptrapdaddr => [ "5.6.7.8", "2.3.4.5:3333" ]' do
       let(:params) {{ :snmptrapdaddr => ['5.6.7.8','2.3.4.5:3333'] }}
       it 'should contain File[snmptrapd.conf] with contents "snmpTrapdAddr 5.6.7.8,2.3.4.5:3333"' do
-        verify_contents(subject, 'snmptrapd.conf', [
+        verify_contents(catalogue, 'snmptrapd.conf', [
           'snmpTrapdAddr 5.6.7.8,2.3.4.5:3333',
         ])
       end
@@ -661,7 +661,7 @@ describe 'snmp', :type => 'class' do
     describe 'snmpd_config => [ "option 1", "option 2", ]' do
       let(:params) {{ :snmpd_config => [ 'option 1', 'option 2', ] }}
       it 'should contain File[snmpd.conf] with contents "option1" and "option 2"' do
-        verify_contents(subject, 'snmpd.conf', [
+        verify_contents(catalogue, 'snmpd.conf', [
           'option 1',
           'option 2',
         ])
@@ -671,7 +671,7 @@ describe 'snmp', :type => 'class' do
     describe 'snmptrapd_config => [ "option 3", "option 4", ]' do
       let(:params) {{ :snmptrapd_config => [ 'option 3', 'option 4', ] }}
       it 'should contain File[snmptrapd.conf] with contents "option 3" and "option 4"' do
-        verify_contents(subject, 'snmptrapd.conf', [
+        verify_contents(catalogue, 'snmptrapd.conf', [
           'option 3',
           'option 4',
         ])
@@ -696,7 +696,7 @@ describe 'snmp', :type => 'class' do
       it { should contain_service('snmpd').with_ensure('running') }
       it { should_not contain_service('snmptrapd') }
       it 'should contain File[snmpd.sysconfig] with contents "SNMPDRUN=no" and "TRAPDRUN=yes"' do
-        verify_contents(subject, 'snmpd.sysconfig', [
+        verify_contents(catalogue, 'snmpd.sysconfig', [
           'SNMPDRUN=no',
           'TRAPDRUN=yes',
         ])
@@ -707,7 +707,7 @@ describe 'snmp', :type => 'class' do
       let(:params) {{ :snmpd_options => 'blah' }}
       it { should contain_file('snmpd.sysconfig') }
       it 'should contain File[snmpd.sysconfig] with contents "SNMPDOPTS=\'blah\'"' do
-        verify_contents(subject, 'snmpd.sysconfig', [
+        verify_contents(catalogue, 'snmpd.sysconfig', [
           'SNMPDOPTS=\'blah\'',
         ])
       end
@@ -717,7 +717,7 @@ describe 'snmp', :type => 'class' do
       let(:params) {{ :snmptrapd_options => 'bleh' }}
       it { should contain_file('snmpd.sysconfig') }
       it 'should contain File[snmpd.sysconfig] with contents "TRAPDOPTS=\'bleh\'"' do
-        verify_contents(subject, 'snmpd.sysconfig', [
+        verify_contents(catalogue, 'snmpd.sysconfig', [
           'TRAPDOPTS=\'bleh\'',
         ])
       end
@@ -758,7 +758,7 @@ describe 'snmp', :type => 'class' do
       let(:params) {{ :snmpd_options => 'blah' }}
       it { should contain_file('snmpd.sysconfig') }
       it 'should contain File[snmpd.sysconfig] with contents "SNMPD_LOGLEVEL="blah""' do
-        verify_contents(subject, 'snmpd.sysconfig', [
+        verify_contents(catalogue, 'snmpd.sysconfig', [
           'SNMPD_LOGLEVEL="blah"',
         ])
       end

--- a/templates/snmpd.conf.erb
+++ b/templates/snmpd.conf.erb
@@ -14,16 +14,16 @@ agentaddress <%= @agentaddress.join(',') %>
 
 # ------------------------------------------------------------------------------
 # Traditional Access Control
-<% if @ro_community -%>
+<% if @ro_community and (@ro_community.size > 0) -%>
 rocommunity <%= @ro_community %> <%= @ro_network %>
 <% end -%>
-<% if @ro_community6 -%>
+<% if @ro_community6 and (@ro_community6.size > 0) -%>
 rocommunity6 <%= @ro_community6 %> <%= @ro_network6 %>
 <% end -%>
-<% if @rw_community -%>
+<% if @rw_community and (@rw_community.size > 0) -%>
 rwcommunity <%= @rw_community %> <%= @rw_network %>
 <% end -%>
-<% if @rw_community6 -%>
+<% if @rw_community6 and (@rw_community6.size > 0) -%>
 rwcommmunity6 <%= @rw_community6 %> <%= @rw_network6 %>
 <% end -%>
 


### PR DESCRIPTION
Ensure that rocommunity and friends can be explicitly disabled
by setting them to the empty string (not undefined).

Solves #36