### PR TITLE
Change OS majdistrelease comparison to integer comparison

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -290,7 +290,7 @@ class snmp::params {
           $varnetsnmp_perms  = '0755'
         }
         default: {
-          if $majdistrelease <= '5' {
+          if $majdistrelease <= 5 {
             $snmpd_options    = '-Lsd -Lf /dev/null -p /var/run/snmpd.pid -a'
             $sysconfig        = '/etc/sysconfig/snmpd.options'
             $trap_sysconfig   = '/etc/sysconfig/snmptrapd.options'


### PR DESCRIPTION
Change OS majdistrelease comparison to integer comparison. Otherwise I get an error, comparison of String with 5 failed at.