### PR TITLE
skip zero length strings in ERB template output

### DIFF
--- a/templates/snmpd.conf.erb
+++ b/templates/snmpd.conf.erb
@@ -14,16 +14,16 @@ agentaddress <%= @agentaddress.join(',') %>
 
 # ------------------------------------------------------------------------------
 # Traditional Access Control
-<% if @ro_community -%>
+<% if @ro_community and (@ro_community.size > 0) -%>
 rocommunity <%= @ro_community %> <%= @ro_network %>
 <% end -%>
-<% if @ro_community6 -%>
+<% if @ro_community6 and (@ro_community6.size > 0) -%>
 rocommunity6 <%= @ro_community6 %> <%= @ro_network6 %>
 <% end -%>
-<% if @rw_community -%>
+<% if @rw_community and (@rw_community.size > 0) -%>
 rwcommunity <%= @rw_community %> <%= @rw_network %>
 <% end -%>
-<% if @rw_community6 -%>
+<% if @rw_community6 and (@rw_community6.size > 0) -%>
 rwcommmunity6 <%= @rw_community6 %> <%= @rw_network6 %>
 <% end -%>
 


### PR DESCRIPTION
Ensure that rocommunity and friends can be explicitly disabled
by setting them to the empty string (not undefined).

Solves #36