### PR TITLE
Add support for OpenBSD

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -1,0 +1,7 @@
+---
+.travis.yml:
+  extras:
+  - rvm: 1.8.7
+    env: PUPPET_GEM_VERSION="~> 2.7.0" FACTER_GEM_VERSION="~> 1.6.0"
+  - rvm: 1.8.7
+    env: PUPPET_GEM_VERSION="~> 2.7.0" FACTER_GEM_VERSION="~> 1.7.0"

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source ENV['GEM_SOURCE'] || "https://rubygems.org"
 
 group :development, :unit_tests do
-  gem 'rake',                                 :require => false
+  gem 'rake', '< 11.0',                       :require => false
   gem 'rspec', '~> 2.0',                      :require => false
   gem 'rspec-puppet', '>= 2.1.0',             :require => false
   gem 'puppetlabs_spec_helper',               :require => false

--- a/README.markdown
+++ b/README.markdown
@@ -245,35 +245,35 @@ An array of addresses, on which snmptrapd will listen to receive incoming SNMP n
 Default: [ udp:127.0.0.1:162, udp6:[::1]:162 ]
 
 #####`ro_community`
-Read-only (RO) community string for snmptrap daemon.
+Read-only (RO) community string or array for snmptrap daemon.
 Default: public
 
 #####`ro_community6`
-Read-only (RO) community string for IPv6.
+Read-only (RO) community string or array for IPv6.
 Default: public
 
 #####`rw_community`
-Read-write (RW) community string.
+Read-write (RW) community string or array.
 Default: none
 
 #####`rw_community6`
-Read-write (RW) community string for IPv6.
+Read-write (RW) community string or array for IPv6.
 Default: none
 
 #####`ro_network`
-Network that is allowed to RO query the daemon.  Can be an array.
+Network that is allowed to RO query the daemon.  Can be string or array.
 Default: 127.0.0.1
 
 #####`ro_network6`
-Network that is allowed to RO query the daemon via IPv6.  Can be an array.
+Network that is allowed to RO query the daemon via IPv6.  Can be string or array.
 Default: ::1/128
 
 #####`rw_network`
-Network that is allowed to RW query the daemon.  Can be an array.
+Network that is allowed to RW query the daemon.  Can be string or array.
 Default: 127.0.0.1
 
 #####`rw_network6`
-Network that is allowed to RW query the daemon via IPv6.  Can be an array.
+Network that is allowed to RW query the daemon via IPv6.  Can be string or array.
 Default: ::1/128
 
 #####`contact`

--- a/README.markdown
+++ b/README.markdown
@@ -488,6 +488,7 @@ Net-SNMP module support is available with these operating systems:
 * SuSE family    - tested on SLES 11 SP1
 * Debian family  - tested on Ubuntu 12.04.2 LTS, Debian 6.0.7, and Debian 7.0
 * FreeBSD family - tested on FreeBSD 9.2-RELEASE, FreeBSD 10.0-RELEASE
+* OpenBSD family - tested on OpenBSD 5.9
 
 ###Notes:
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -441,7 +441,7 @@ class snmp (
     notify  => Service['snmpd'],
   }
 
-  if $::osfamily != 'FreeBSD' {
+  if $::osfamily != 'FreeBSD' and $::osfamily != 'OpenBSD' {
     file { 'snmpd.sysconfig':
       ensure  => $file_ensure,
       mode    => '0644',
@@ -504,7 +504,7 @@ class snmp (
         Exec['install /etc/init.d/snmptrapd'],
       ],
     }
-  } elsif $::osfamily == 'FreeBSD' {
+  } elsif $::osfamily == 'FreeBSD'  or $::osfamily == 'OpenBSD' {
     service { 'snmptrapd':
       ensure     => $trap_service_ensure_real,
       name       => $trap_service_name,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -14,35 +14,35 @@
 #   Default: [ udp:127.0.0.1:162, udp6:[::1]:162 ]
 #
 # [*ro_community*]
-#   Read-only (RO) community string for snmptrap daemon.
+#   Read-only (RO) community string or array for snmptrap daemon.
 #   Default: public
 #
 # [*ro_community6*]
-#   Read-only (RO) community string for IPv6.
+#   Read-only (RO) community string or array for IPv6.
 #   Default: public
 #
 # [*rw_community*]
-#   Read-write (RW) community string.
+#   Read-write (RW) community string or array.
 #   Default: none
 #
 # [*rw_community6*]
-#   Read-write (RW) community string for IPv6.
+#   Read-write (RW) community string or array for IPv6.
 #   Default: none
 #
 # [*ro_network*]
-#   Network that is allowed to RO query the daemon.  Can be an array.
+#   Network that is allowed to RO query the daemon.  Can be string or array.
 #   Default: 127.0.0.1
 #
 # [*ro_network6*]
-#   Network that is allowed to RO query the daemon via IPv6.  Can be an array.
+#   Network that is allowed to RO query the daemon via IPv6.  Can be string or array.
 #   Default: ::1/128
 #
 # [*rw_network*]
-#   Network that is allowed to RW query the daemon.  Can be an array.
+#   Network that is allowed to RW query the daemon.  Can be string or array.
 #   Default: 127.0.0.1
 #
 # [*rw_network6*]
-#   Network that is allowed to RW query the daemon via IPv6.  Can be an array.
+#   Network that is allowed to RW query the daemon via IPv6.  Can be string or array.
 #   Default: ::1/128
 #
 # [*contact*]
@@ -289,6 +289,7 @@ class snmp (
   $autoupgrade             = $snmp::params::safe_autoupgrade,
   $package_name            = $snmp::params::package_name,
   $snmpd_options           = $snmp::params::snmpd_options,
+  $service_config_perms    = $snmp::params::service_config_perms,
   $service_ensure          = $snmp::params::service_ensure,
   $service_name            = $snmp::params::service_name,
   $service_enable          = $snmp::params::service_enable,
@@ -315,6 +316,9 @@ class snmp (
   validate_array($trap_handlers)
   validate_array($trap_forwards)
   validate_array($snmp_config)
+  validate_array($com2sec)
+  validate_array($com2sec6)
+  validate_array($groups)
   validate_array($views)
   validate_array($accesses)
   validate_array($dlmod)
@@ -428,7 +432,7 @@ class snmp (
 
   file { 'snmpd.conf':
     ensure  => $file_ensure,
-    mode    => $snmp::params::service_config_perms,
+    mode    => $service_config_perms,
     owner   => 'root',
     group   => $snmp::params::service_config_dir_group,
     path    => $snmp::params::service_config,
@@ -452,7 +456,7 @@ class snmp (
 
   file { 'snmptrapd.conf':
     ensure  => $file_ensure,
-    mode    => $snmp::params::service_config_perms,
+    mode    => $service_config_perms,
     owner   => 'root',
     group   => $snmp::params::service_config_dir_group,
     path    => $snmp::params::trap_service_config,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -30,7 +30,7 @@ class snmp::params {
     undef   => 'public',
     default => $::snmp_ro_community,
   }
-  
+
   $ro_community6 = $::snmp_ro_community6 ? {
     undef   => 'public',
     default => $::snmp_ro_community6,
@@ -40,7 +40,7 @@ class snmp::params {
     undef   => undef,
     default => $::snmp_rw_community,
   }
-  
+
   $rw_community6 = $::snmp_rw_community6 ? {
     undef   => undef,
     default => $::snmp_rw_community6,
@@ -60,7 +60,7 @@ class snmp::params {
     undef   => '127.0.0.1',
     default => $::snmp_rw_network,
   }
-  
+
   $rw_network6 = $::snmp_rw_network6 ? {
     undef   => '::1',
     default => $::snmp_rw_network6,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -395,6 +395,28 @@ class snmp::params {
       $trap_service_name        = 'snmptrapd'
       $snmptrapd_options        = undef
     }
+    'OpenBSD': {
+      $package_name             = 'net-snmp'
+      $service_config_dir_path  = '/etc/snmp'
+      $service_config_dir_perms = '0755'
+      $service_config_dir_owner = 'root'
+      $service_config_dir_group = 'wheel'
+      $service_config           = '/etc/snmp/snmpd.conf'
+      $service_config_perms     = '0755'
+      $service_name             = 'netsnmpd'
+      $snmpd_options            = undef
+      $var_net_snmp             = '/var/net-snmp'
+      $varnetsnmp_perms         = '0600'
+      $varnetsnmp_owner         = '_netsnmp'
+      $varnetsnmp_group         = 'wheel'
+
+      $client_package_name      = 'net-snmp'
+      $client_config            = '/etc/snmp/snmp.conf'
+
+      $trap_service_config      = '/etc/snmp/snmptrapd.conf'
+      $trap_service_name        = 'netsnmptrapd'
+      $snmptrapd_options        = undef
+    }
     default: {
       fail("Module ${::module} is not supported on ${::operatingsystem}")
     }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "razorsedge-snmp",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "author": "razorsedge",
   "summary": "Simple Network Management Protocol is for monitoring network and computer equipment. Net-SNMP implements v1, v2c, and v3 on both IPv4 and IPv6.",
   "license": "Apache-2.0",

--- a/metadata.json
+++ b/metadata.json
@@ -32,6 +32,10 @@
       "operatingsystemrelease": [ "9.2", "10.0" ]
     },
     {
+      "operatingsystem": "OpenBSD",
+      "operatingsystemrelease": [ "5.9" ]
+    },
+    {
       "operatingsystem": "SLES",
       "operatingsystemrelease": [ "11 SP1" ]
     },

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "razorsedge-snmp",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "author": "razorsedge",
   "summary": "Simple Network Management Protocol is for monitoring network and computer equipment. Net-SNMP implements v1, v2c, and v3 on both IPv4 and IPv6.",
   "license": "Apache-2.0",

--- a/spec/classes/snmp_client_spec.rb
+++ b/spec/classes/snmp_client_spec.rb
@@ -24,6 +24,7 @@ describe 'snmp::client', :type => 'class' do
   #debianish = ['Debian', 'Ubuntu']
   suseish = ['Suse']
   freebsdish = ['FreeBSD']
+  openbsdish = ['OpenBSD']
 
   context 'on a supported osfamily, default parameters' do
     redhatish.each do |os|
@@ -114,6 +115,30 @@ describe 'snmp::client', :type => 'class' do
           :owner   => 'root',
           :group   => 'wheel',
           :path    => '/usr/local/etc/snmp/snmp.conf',
+          :require => nil
+        )}
+      end
+    end
+
+    openbsdish.each do |os|
+      describe "for osfamily OpenBSD, operatingsystem #{os}" do
+        let(:params) {{}}
+        let :facts do {
+          :osfamily               => 'OpenBSD',
+          :operatingsystem        => os,
+          :operatingsystemrelease => '5.9'
+        }
+        end
+        it { should contain_package('snmp-client').with(
+          :ensure => 'present',
+          :name   => 'net-snmp'
+        )}
+        it { should_not contain_file('snmp.conf').with(
+          :ensure  => 'present',
+          :mode    => '0755',
+          :owner   => 'root',
+          :group   => 'wheel',
+          :path    => '/etc/snmp/snmp.conf',
           :require => nil
         )}
       end

--- a/spec/classes/snmp_init_spec.rb
+++ b/spec/classes/snmp_init_spec.rb
@@ -624,6 +624,12 @@ describe 'snmp', :type => 'class' do
       end
     end
 
+    describe 'service_config_perms => "0123"' do
+      let(:params) {{ :service_config_perms => '0123' }}
+      it { should contain_file('snmpd.conf').with_mode('0123') }
+      it { should contain_file('snmptrapd.conf').with_mode('0123') }
+    end
+
     describe 'install_client => true' do
       let(:params) {{ :install_client => true }}
       it { should contain_class('snmp::client').with(
@@ -719,9 +725,29 @@ describe 'snmp', :type => 'class' do
 
     describe 'groups => [ SomeString ]' do
       let(:params) {{ :groups => [ 'SomeString', ] }}
-      it 'should contain File[snmpd.conf] with contents "groups SomeString"' do
+      it 'should contain File[snmpd.conf] with contents "group SomeString"' do
         verify_contents(catalogue, 'snmpd.conf', [
           'group   SomeString',
+        ])
+      end
+    end
+
+    describe 'views => [ "SomeArray1", "SomeArray2" ]' do
+      let(:params) {{ :views => [ 'SomeArray1', 'SomeArray2' ] }}
+      it 'should contain File[snmpd.conf] with contents from array' do
+        verify_contents(catalogue, 'snmpd.conf', [
+          'view    SomeArray1',
+          'view    SomeArray2',
+        ])
+      end
+    end
+
+    describe 'accesses => [ "SomeArray1", "SomeArray2" ]' do
+      let(:params) {{ :accesses => [ 'SomeArray1', 'SomeArray2' ] }}
+      it 'should contain File[snmpd.conf] with contents from array' do
+        verify_contents(catalogue, 'snmpd.conf', [
+          'access  SomeArray1',
+          'access  SomeArray2',
         ])
       end
     end
@@ -797,6 +823,25 @@ describe 'snmp', :type => 'class' do
         verify_contents(catalogue, 'snmpd.conf', [
           'rocommunity public 127.0.0.1',
           'rocommunity public 192.168.1.1/24',
+        ])
+      end
+    end
+
+    describe 'ro_network => "127.0.0.2"' do
+      let(:params) {{ :ro_network => '127.0.0.2' }}
+      it 'should contain File[snmpd.conf] with contents "127.0.0.2"' do
+        verify_contents(catalogue, 'snmpd.conf', [
+          'rocommunity public 127.0.0.2',
+        ])
+      end
+    end
+
+    describe 'ro_community => [ "a", "b", ] and ro_network => "127.0.0.2"' do
+      let(:params) {{ :ro_community => ['a', 'b'], :ro_network => '127.0.0.2' }}
+      it 'should contain File[snmpd.conf] with contents "a 127.0.0.2" and "b 127.0.0.2"' do
+        verify_contents(catalogue, 'snmpd.conf', [
+          'rocommunity a 127.0.0.2',
+          'rocommunity b 127.0.0.2',
         ])
       end
     end

--- a/spec/classes/snmp_init_spec.rb
+++ b/spec/classes/snmp_init_spec.rb
@@ -24,6 +24,7 @@ describe 'snmp', :type => 'class' do
   #debianish = ['Debian', 'Ubuntu']
   suseish = ['Suse']
   freebsdish = ['FreeBSD']
+  openbsdish = ['OpenBSD']
 
   context 'on a supported osfamily, default parameters' do
       describe "for osfamily RedHat, operatingsystem RedHat, operatingsystemrelease 5.9" do
@@ -554,6 +555,96 @@ describe 'snmp', :type => 'class' do
         it { should contain_service('snmptrapd').with(
           :ensure     => 'stopped',
           :name       => 'snmptrapd',
+          :enable     => false,
+          :hasstatus  => true,
+          :hasrestart => true,
+          :require    => [ 'Package[snmpd]', 'File[var-net-snmp]', ]
+        )}
+      end
+    end
+
+    openbsdish.each do |os|
+      describe "for osfamily OpenBSD, operatingsystem #{os}" do
+        let(:params) {{}}
+        let :facts do {
+          :osfamily               => 'OpenBSD',
+          :operatingsystem        => os,
+          :operatingsystemrelease => '5.9',
+          :fqdn                   => 'myhost4.localdomain'
+        }
+        end
+        it { should contain_package('snmpd').with(
+          :ensure => 'present',
+          :name   => 'net-snmp'
+        )}
+        it { should_not contain_class('snmp::client') }
+        it { should contain_file('var-net-snmp').with(
+          :ensure  => 'directory',
+          :mode    => '0600',
+          :owner   => '_netsnmp',
+          :group   => 'wheel',
+          :path    => '/var/net-snmp',
+          :require => 'Package[snmpd]'
+        )}
+
+        it { should contain_file('snmpd.conf').with(
+          :ensure  => 'present',
+          :mode    => '0755',
+          :owner   => 'root',
+          :group   => 'wheel',
+          :path    => '/etc/snmp/snmpd.conf',
+          :require => 'Package[snmpd]',
+          :notify  => 'Service[snmpd]'
+        )}
+        # TODO add more contents for File[snmpd.conf]
+        it 'should contain File[snmpd.conf] with expected contents' do
+          verify_contents(catalogue, 'snmpd.conf', [
+            'agentaddress udp:127.0.0.1:161,udp6:[::1]:161',
+            'rocommunity public 127.0.0.1',
+            'rocommunity6 public ::1',
+            'com2sec notConfigUser  default       public',
+            'com2sec6 notConfigUser  default       public',
+            'group   notConfigGroup v1            notConfigUser',
+            'group   notConfigGroup v2c           notConfigUser',
+            'view    systemview    included   .1.3.6.1.2.1.1',
+            'view    systemview    included   .1.3.6.1.2.1.25.1.1',
+            'access  notConfigGroup ""      any       noauth    exact  systemview none  none',
+            'sysLocation Unknown',
+            'sysContact Unknown',
+            'sysServices 72',
+            'sysName myhost4.localdomain',
+            'dontLogTCPWrappersConnects no',
+          ])
+        end
+        it { should contain_service('snmpd').with(
+          :ensure     => 'running',
+          :name       => 'netsnmpd',
+          :enable     => true,
+          :hasstatus  => true,
+          :hasrestart => true,
+          :require    => [ 'Package[snmpd]', 'File[var-net-snmp]', ]
+        )}
+
+        it { should contain_file('snmptrapd.conf').with(
+          :ensure  => 'present',
+          :mode    => '0755',
+          :owner   => 'root',
+          :group   => 'wheel',
+          :path    => '/etc/snmp/snmptrapd.conf',
+          :require => 'Package[snmpd]',
+          :notify  => 'Service[snmptrapd]'
+        )}
+        # TODO add more contents for File[snmptrapd.conf]
+        it 'should contain File[snmptrapd.conf] with correct contents' do
+          verify_contents(catalogue, 'snmptrapd.conf', [
+            'doNotLogTraps no',
+            'authCommunity log,execute,net public',
+            'disableAuthorization no',
+          ])
+        end
+        it { should contain_service('snmptrapd').with(
+          :ensure     => 'stopped',
+          :name       => 'netsnmptrapd',
           :enable     => false,
           :hasstatus  => true,
           :hasrestart => true,

--- a/templates/snmpd.conf.erb
+++ b/templates/snmpd.conf.erb
@@ -14,63 +14,41 @@ agentaddress <%= @agentaddress.join(',') %>
 
 # ------------------------------------------------------------------------------
 # Traditional Access Control
-<% if @ro_community and (@ro_community.size > 0) -%>
-<% if (@ro_network.is_a?(Array)) and (@ro_network.count > 0) -%>
-<% @ro_network.each do |ro_net| -%>
-rocommunity <%= @ro_community %> <%= ro_net %>
-<% end -%>
-<% else -%>
-rocommunity <%= @ro_community %> <%= @ro_network %>
-<% end -%>
-<% end -%>
-<% if @ro_community6 and (@ro_community6.size > 0) -%>
-<% if (@ro_network6.is_a?(Array)) and (@ro_network6.count > 0) -%>
-<% @ro_network6.each do |ro_net6| -%>
-rocommunity6 <%= @ro_community6 %> <%= ro_net6 %>
-<% end -%>
-<% else -%>
-rocommunity6 <%= @ro_community6 %> <%= @ro_network6 %>
-<% end -%>
-<% end -%>
-<% if @rw_community and (@rw_community.size > 0) -%>
-<% if (@rw_network.is_a?(Array)) and (@rw_network.count > 0) -%>
-<% @rw_network.each do |rw_net| -%>
-rwcommunity <%= @rw_community %> <%= rw_net %>
-<% end -%>
-<% else -%>
-rwcommunity <%= @rw_community %> <%= @rw_network %>
-<% end -%>
-<% end -%>
-<% if @rw_community6 and (@rw_community6.size > 0) -%>
-<% if (@rw_network6.is_a?(Array)) and (@rw_network6.count > 0) -%>
-<% @rw_network6.each do |rw_net6| -%>
-rwcommunity6 <%= @rw_community6 %> <%= rw_net6 %>
-<% end -%>
-<% else -%>
-rwcommunity6 <%= @rw_community6 %> <%= @rw_network6 %>
-<% end -%>
-<% end -%>
+<%- [*@ro_community].compact.each do |c| -%>
+  <%- [*@ro_network].compact.each do |n| -%>
+rocommunity <%= c %> <%= n %>
+  <%- end -%>
+<%- end -%>
+<%- [*@ro_community6].compact.each do |c| -%>
+  <%- [*@ro_network6].compact.each do |n| -%>
+rocommunity6 <%= c %> <%= n %>
+  <%- end -%>
+<%- end -%>
+<%- [*@rw_community].compact.each do |c| -%>
+  <%- [*@rw_network].compact.each do |n| -%>
+rwcommunity <%= c %> <%= n %>
+  <%- end -%>
+<%- end -%>
+<%- [*@rw_community6].compact.each do |c| -%>
+  <%- [*@rw_network6].compact.each do |n| -%>
+rocommunity6 <%= c %> <%= n %>
+  <%- end -%>
+<%- end -%>
 
 # ------------------------------------------------------------------------------
 # VACM Configuration
 #       sec.name       source        community
-<% if @com2sec.any? -%>
-<% @com2sec.each do |com2sec| -%>
-com2sec <%= com2sec %>
-<% end -%>
+<% @com2sec.each do |c| -%>
+com2sec <%= c %>
 <% end -%>
 
-<% if @com2sec6.any? -%>
-<% @com2sec6.each do |com2sec6| -%>
-com2sec6 <%= com2sec6 %>
-<% end -%>
+<% @com2sec6.each do |c| -%>
+com2sec6 <%= c %>
 <% end -%>
 
 #       groupName      securityModel securityName
-<% if @groups.any? -%>
 <% @groups.each do |group| -%>
 group   <%= group %>
-<% end -%>
 <% end -%>
 
 #       name          incl/excl  subtree             mask(optional)


### PR DESCRIPTION
This adds OpenBSD to the supported operating systems, similar to the FreeBSD
support. Added spec tests for OpenBSD and mention it in README and
metadata.json.

Note that travis-ci seems to have problems with the Ruby 1.8 tests, which as far as I can
see are not related to the PR. The other spec tests are fine.

Hope this can be considered for merge. If there is something to enhance/fix etc. please let me know and I'll take care.

cheers