### PR TITLE
Update for travis-ci not having proper rake version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,33 +1,60 @@
 ---
 language: ruby
-cache:
-  directories:
-  - vendor/bundle
-#  - spec/fixtures/modules
+bundler_args: --without development
+before_install: rm Gemfile.lock || true
 sudo: false
-branches:
-  only:
-    - master
-    - develop
-bundler_args: --without system_tests
+rvm:
+  - 1.8.7
+  - 1.9.3
+  - 2.1.0
+  - 2.2
 script: "bundle exec rake validate && bundle exec rake lint && bundle exec rake spec SPEC_OPTS='--format documentation'"
+env:
+  - PUPPET_GEM_VERSION="~> 3.6.0"
+  - PUPPET_GEM_VERSION="~> 3.6.0" STRICT_VARIABLES=yes
+  - PUPPET_GEM_VERSION="~> 3.7.0"
+  - PUPPET_GEM_VERSION="~> 3.7.0" STRICT_VARIABLES=yes
+  - PUPPET_GEM_VERSION="~> 3.7.0" STRICT_VARIABLES=yes FUTURE_PARSER=yes
+  - PUPPET_GEM_VERSION="~> 3.8.0" 
+  - PUPPET_GEM_VERSION="~> 3.8.0" STRICT_VARIABLES=yes
+  - PUPPET_GEM_VERSION="~> 3.8.0" STRICT_VARIABLES=yes FUTURE_PARSER=yes
+  - PUPPET_GEM_VERSION="~> 4.0.0"
+  - PUPPET_GEM_VERSION="~> 4.1.0"
+  - PUPPET_GEM_VERSION="~> 4.2.0"
+  - PUPPET_GEM_VERSION="~> 4.3.0"
+  - PUPPET_GIT_URL="https://github.com/puppetlabs/puppet.git"
 matrix:
+  allow_failures:
+    - env: PUPPET_GEM_VERSION="~> 3.6.0" STRICT_VARIABLES=yes
+    - env: PUPPET_GEM_VERSION="~> 3.7.0" STRICT_VARIABLES=yes
+    - env: PUPPET_GEM_VERSION="~> 3.7.0" STRICT_VARIABLES=yes FUTURE_PARSER=yes
+    - env: PUPPET_GEM_VERSION="~> 3.8.0" STRICT_VARIABLES=yes
+    - env: PUPPET_GEM_VERSION="~> 3.8.0" STRICT_VARIABLES=yes FUTURE_PARSER=yes
   fast_finish: true
-  include:
-  - rvm: 1.8.7
-    env: PUPPET_GEM_VERSION="~> 2.7.0" FACTER_GEM_VERSION="~> 1.6.0"
-  - rvm: 1.8.7
-    env: PUPPET_GEM_VERSION="~> 2.7.0" FACTER_GEM_VERSION="~> 1.7.0"
-  - rvm: 1.8.7
-    env: PUPPET_GEM_VERSION="~> 3.0"
-  - rvm: 1.9.3
-    env: PUPPET_GEM_VERSION="~> 3.0"
-  - rvm: 2.0.0
-    env: PUPPET_GEM_VERSION="~> 3.0"
-  - rvm: 2.1.0
-    env: PUPPET_GEM_VERSION="~> 3.0"
-  - rvm: 2.1.0
-    env: PUPPET_GEM_VERSION="~> 4.0"
-notifications:
-  email:
-    - github@razorsedge.org
+  exclude:
+    - rvm: 1.8.7
+      env: PUPPET_GEM_VERSION="~> 4.0.0"
+    - rvm: 1.8.7
+      env: PUPPET_GEM_VERSION="~> 4.1.0"
+    - rvm: 1.8.7
+      env: PUPPET_GEM_VERSION="~> 4.3.0"
+    - rvm: 1.8.7
+      env: PUPPET_GEM_VERSION="~> 4.2.0"
+    - rvm: 1.8.7
+      env: PUPPET_GIT_URL="https://github.com/puppetlabs/puppet.git"
+    - rvm: 2.2
+      env: PUPPET_GEM_VERSION="~> 3.6.0"
+    - rvm: 2.2
+      env: PUPPET_GEM_VERSION="~> 3.6.0" STRICT_VARIABLES=yes
+    - rvm: 2.2
+      env: PUPPET_GEM_VERSION="~> 3.7.0"
+    - rvm: 2.2
+      env: PUPPET_GEM_VERSION="~> 3.7.0" STRICT_VARIABLES=yes
+    - rvm: 2.2
+      env: PUPPET_GEM_VERSION="~> 3.7.0" STRICT_VARIABLES=yes FUTURE_PARSER=yes
+    - rvm: 2.2
+      env: PUPPET_GEM_VERSION="~> 3.8.0"
+    - rvm: 2.2
+      env: PUPPET_GEM_VERSION="~> 3.8.0" STRICT_VARIABLES=yes
+    - rvm: 2.2
+      env: PUPPET_GEM_VERSION="~> 3.8.0" STRICT_VARIABLES=yes FUTURE_PARSER=yes

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source ENV['GEM_SOURCE'] || "https://rubygems.org"
 
 group :development, :unit_tests do
-  gem 'rake',                                 :require => false
+  gem "rake", "~> 10.0"
   gem 'rspec', '~> 2.0',                      :require => false
   gem 'rspec-puppet', '>= 2.1.0',             :require => false
   gem 'puppetlabs_spec_helper',               :require => false


### PR DESCRIPTION
Expanding the testing for puppet-snmp, i'm also allowing for now that enabling strict fails.

