### PR TITLE
Change - Update requirements for the snmp::client class

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -77,9 +77,12 @@ class snmp::client (
       ensure => $package_ensure,
       name   => $package_name,
     }
-    $req = Package['snmp-client']
-  } else {
-    $req = undef
+  }
+
+  $req = $::osfamily ? {
+    'RedHat' => [Package['snmp-client'], Package[$snmp::params::package_name]],
+    'Suse'   => undef,
+    default  => Package['snmp-client'],
   }
 
   file { 'snmp.conf':

--- a/spec/classes/snmp_client_spec.rb
+++ b/spec/classes/snmp_client_spec.rb
@@ -46,7 +46,7 @@ describe 'snmp::client', :type => 'class' do
           :owner   => 'root',
           :group   => 'root',
           :path    => '/etc/snmp/snmp.conf',
-          :require => 'Package[snmp-client]'
+          :require => ['Package[snmp-client]', 'Package[net-snmp]']
         )}
       end
     end


### PR DESCRIPTION
To avoid missing directory errors on Redhat based systems the net-snmp
package needs to be installed before the snmp.conf file is created.