### PR TITLE
Change - Update to work with OpenSUSE Tumbleweed

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -72,7 +72,7 @@ class snmp::client (
     }
   }
 
-  if $::osfamily != 'Suse' {
+  if $::osfamily !~ /(Suse|Linux)/ {
     package { 'snmp-client':
       ensure => $package_ensure,
       name   => $package_name,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -504,7 +504,7 @@ class snmp (
       hasrestart => $trap_service_hasrestart,
       require    => [ Package['snmpd'], File['var-net-snmp'], ],
     }
-  } elsif $::osfamily == 'Suse' {
+  } elsif $::osfamily =~ /(Suse|Linux)/ {
     exec { 'install /etc/init.d/snmptrapd':
       command => '/usr/bin/install -o 0 -g 0 -m0755 -p /usr/share/doc/packages/net-snmp/rc.snmptrapd /etc/init.d/snmptrapd',
       creates => '/etc/init.d/snmptrapd',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -361,7 +361,9 @@ class snmp::params {
       $trap_service_config      = '/etc/snmp/snmptrapd.conf'
       $snmptrapd_options        = '-Lsd -p /var/run/snmptrapd.pid'
     }
-    'Suse': {
+
+    #OpenSUSE Tumbleweed reports the osfamily as 'Linux'.  Leap reports osfamily as 'Suse'.
+    /(Linux|Suse)/: {
       $package_name             = 'net-snmp'
       $service_config           = '/etc/snmp/snmpd.conf'
       $service_config_perms     = '0600'

--- a/templates/snmpd.sysconfig-Linux.erb
+++ b/templates/snmpd.sysconfig-Linux.erb
@@ -1,0 +1,5 @@
+###
+### File managed by Puppet
+###
+# snmpd command line options
+OPTIONS="<%= @snmpd_options %>"

--- a/templates/snmptrapd.sysconfig-Linux.erb
+++ b/templates/snmptrapd.sysconfig-Linux.erb
@@ -1,0 +1,5 @@
+###
+### File managed by Puppet
+###
+# snmptrapd command line options
+OPTIONS="<%= @snmptrapd_options %>"


### PR DESCRIPTION
Updated operating system checks to use a regex pattern on OpenSUSE
nodes.  This avoids issues with case sensitivity in the OS name.  OpenSUSE Leap and OpenSUSE Tumbleweed report the osfamily fact differently which makes using a regex necessary.