### PR TITLE
Update requirements for the snmp client class

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -77,9 +77,18 @@ class snmp::client (
       ensure => $package_ensure,
       name   => $package_name,
     }
-    $req = Package['snmp-client']
-  } else {
-    $req = undef
+  }
+
+  if $::osfamily == 'RedHat' {
+    file { '/etc/snmp':
+      ensure => directory,
+    }
+  }
+
+  $req = $::osfamily ? {
+    'RedHat' => [Package['snmp-client'], File['/etc/snmp']],
+    'Suse'   => undef,
+    default  => Package['snmp-client'],
   }
 
   file { 'snmp.conf':

--- a/spec/classes/snmp_client_spec.rb
+++ b/spec/classes/snmp_client_spec.rb
@@ -46,7 +46,7 @@ describe 'snmp::client', :type => 'class' do
           :owner   => 'root',
           :group   => 'root',
           :path    => '/etc/snmp/snmp.conf',
-          :require => 'Package[snmp-client]'
+          :require => ['Package[snmp-client]', 'File[/etc/snmp]']
         )}
       end
     end


### PR DESCRIPTION
I believe this is a better solution instead of installing the entire net-snmp package.  Puppet run was successful as shown in the attached screenshot.

![screenshot_2017-05-23_11-51-54](https://cloud.githubusercontent.com/assets/18019703/26363406/f13bfb46-3fae-11e7-9b00-2a23752f4b88.png)
