### PR TITLE
adding possibility to define extend lines in snmpd.conf

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,10 +26,8 @@ matrix:
     env: PUPPET_GEM_VERSION="~> 4.0" STRICT_VARIABLES="no"
   - rvm: 2.1.9
     env: PUPPET_GEM_VERSION="~> 4.0"
-  - rvm: 2.3.1
-    env: PUPPET_GEM_VERSION="~> 4.0" STRICT_VARIABLES="no"
-  - rvm: 2.3.1
-    env: PUPPET_GEM_VERSION="~> 4.0"
+  - rvm: 2.4.1
+    env: PUPPET_GEM_VERSION="~> 5.0"
   - rvm: 1.8.7
     env: PUPPET_GEM_VERSION="~> 2.7.0" FACTER_GEM_VERSION="~> 1.6.0"
   - rvm: 1.8.7
@@ -37,10 +35,8 @@ matrix:
   allow_failures:
   - rvm: 2.1.9
     env: PUPPET_GEM_VERSION="~> 4.0"
-  - rvm: 2.3.1
-    env: PUPPET_GEM_VERSION="~> 4.0" STRICT_VARIABLES="no"
-  - rvm: 2.3.1
-    env: PUPPET_GEM_VERSION="~> 4.0"
+  - rvm: 2.4.1
+    env: PUPPET_GEM_VERSION="~> 5.0"
 notifications:
   email:
     - github@razorsedge.org

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,6 @@ matrix:
   - rvm: 2.0.0
     env: PUPPET_GEM_VERSION="~> 3.0" FUTURE_PARSER="yes"
   - rvm: 2.1.9
-    env: PUPPET_GEM_VERSION="~> 4.0" STRICT_VARIABLES="no"
-  - rvm: 2.1.9
     env: PUPPET_GEM_VERSION="~> 4.0"
   - rvm: 2.4.1
     env: PUPPET_GEM_VERSION="~> 5.0"
@@ -33,8 +31,6 @@ matrix:
   - rvm: 1.8.7
     env: PUPPET_GEM_VERSION="~> 2.7.0" FACTER_GEM_VERSION="~> 1.7.0"
   allow_failures:
-  - rvm: 2.1.9
-    env: PUPPET_GEM_VERSION="~> 4.0"
   - rvm: 2.4.1
     env: PUPPET_GEM_VERSION="~> 5.0"
 notifications:

--- a/README.markdown
+++ b/README.markdown
@@ -327,6 +327,10 @@ Default: [ 'notConfigGroup "" any noauth exact systemview none none' ]
 Array of dlmod lines to add to the snmpd.conf file.  Must provide NAME and PATH (ex. "cmaX /usr/lib64/libcmaX64.so").  See http://www.net-snmp.org/docs/man/snmpd.conf.html#lbBD for details.
 Default: []
 
+##### `extends`
+Array of extend lines to add to the snmpd.conf file.  Must provide NAME, PROG and ARG.  See http://www.net-snmp.org/docs/man/snmpd.conf.html#lbBA for details.
+Default: []
+
 ##### `snmpd_config`
 Safety valve.  Array of lines to add to the snmpd.conf file.  See http://www.net-snmp.org/docs/man/snmpd.conf.html for all options.
 Default: []

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -100,6 +100,12 @@
 #   See http://www.net-snmp.org/docs/man/snmpd.conf.html#lbBD for details.
 #   Default: []
 #
+# [*extends*]
+#   Array of extend lines to add to the snmpd.conf file.
+#   Must provide NAME, PROG and ARG.
+#   See http://www.net-snmp.org/docs/man/snmpd.conf.html#lbBA for details.
+#   Default: []
+#
 # [*snmpd_config*]
 #   Safety valve.  Array of lines to add to the snmpd.conf file.
 #   See http://www.net-snmp.org/docs/man/snmpd.conf.html for all options.
@@ -308,6 +314,7 @@ class snmp (
   $views                        = $snmp::params::views,
   $accesses                     = $snmp::params::accesses,
   $dlmod                        = $snmp::params::dlmod,
+  $extends                      = $snmp::params::extends,
   $snmpd_config                 = $snmp::params::snmpd_config,
   $disable_authorization        = $snmp::params::disable_authorization,
   $do_not_log_traps             = $snmp::params::do_not_log_traps,
@@ -367,6 +374,7 @@ class snmp (
   validate_array($views)
   validate_array($accesses)
   validate_array($dlmod)
+  validate_array($extends)
   validate_array($snmpd_config)
   validate_array($snmptrapd_config)
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -462,7 +462,7 @@ class snmp (
   }
 
   if $real_manage_client {
-    class { '::snmp::client':
+    class { 'snmp::client':
       ensure      => $ensure,
       autoupgrade => $autoupgrade,
       snmp_config => $snmp_config,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -454,7 +454,7 @@ class snmp (
   }
 
   if $real_manage_client {
-    class { 'snmp::client':
+    class { '::snmp::client':
       ensure      => $ensure,
       autoupgrade => $autoupgrade,
       snmp_config => $snmp_config,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -213,6 +213,13 @@ class snmp::params {
     $dlmod =  []
   }
 
+  $snmp_extends = getvar('::snmp_extends')
+  if $snmp_extends {
+    $extemds =  $::snmp_extends
+  } else {
+    $extends =  []
+  }
+
   $snmp_disable_authorization = getvar('::snmp_disable_authorization')
   if $snmp_disable_authorization {
     $disable_authorization =  $::snmp_disable_authorization

--- a/spec/classes/snmp_init_spec.rb
+++ b/spec/classes/snmp_init_spec.rb
@@ -870,6 +870,16 @@ describe 'snmp', :type => 'class' do
       end
     end
 
+    describe 'extends => [ "SomeArray1", "SomeArray2" ]' do
+      let(:params) {{ :extends => [ 'SomeArray1', 'SomeArray2' ] }}
+      it 'should contain File[snmpd.conf] with contents from array' do
+        verify_contents(catalogue, 'snmpd.conf', [
+          'extend SomeArray1',
+          'extend SomeArray2',
+        ])
+      end
+    end
+
     describe 'openmanage_enable => true' do
         let(:params) {{ :openmanage_enable => true }}
         it 'should contain File[snmpd.conf] with contents "smuxpeer .1.3.6.1.4.1.674.10892.1"' do

--- a/templates/snmpd.conf.erb
+++ b/templates/snmpd.conf.erb
@@ -98,6 +98,11 @@ sysName <%= @sysname %>
 
 ################################################################################
 # EXTENDING AGENT FUNCTIONALITY
+<% if @extends.any? -%>
+<% @extends.each do |extending| -%>
+extend <%= extending %>
+<% end -%>
+<% end -%>
 
 <% if @dlmod.any? -%>
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
added possibility to add "extend" lines into snmpd config as this does not seem to be possible so far.

for example in pp:
extends => ['pcluster_check_shaman /bin/sh /usr/local/scripts/check_pcluster.sh shaman']

will end up in snmpd.conf
extend pcluster_check_shaman /bin/sh /usr/local/scripts/check_pcluster.sh shaman